### PR TITLE
Remove `plugin = true` in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 
 name = "debug_unreachable"
 path = "src/lib.rs"
-plugin = true
 
 [dependencies]
 unreachable = "0"


### PR DESCRIPTION
Macros are not plugins. `plugin = true` causes this error when building a static library that (recursively) depends on debug-unreachable:

```
error: dependency `debug_unreachable` not found in rlib format
error: aborting due to previous error
```
