### PR TITLE
Add no_std support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs, warnings)]
 
+#![no_std]
+
 //! `panic!()` in debug builds, optimization hint in release.
 
 extern crate unreachable;


### PR DESCRIPTION
I haven't added a feature for this as there's no feature in [unreachable](https://github.com/reem/rust-unreachable/blob/master/Cargo.toml) itself to enable.
